### PR TITLE
Add KPI explorer page with automatic suggestions

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,67 +1,174 @@
-import streamlit as st
 import pandas as pd
-import matplotlib.pyplot as plt
+import streamlit as st
+
 from data_agent import DataExplorerAgent
+from kpi_analyzer import KPIAnalyzer, KPIMetric
 
 st.set_page_config(page_title="Dataset Previewer", layout="wide")
 st.title("📊 Dataset Previewer")
+
+
+def load_dataset(upload) -> pd.DataFrame | None:
+    file_name = upload.name.lower()
+    try:
+        if file_name.endswith(".csv"):
+            df = pd.read_csv(upload)
+        elif file_name.endswith((".xlsx", ".xls")):
+            df = pd.read_excel(upload)
+        elif file_name.endswith(".parquet"):
+            df = pd.read_parquet(upload)
+        elif file_name.endswith(".json"):
+            df = pd.read_json(upload)
+        else:
+            st.error("❌ Format non supporté.")
+            return None
+    except Exception as exc:
+        st.error(f"Erreur lors de la lecture du fichier : {exc}")
+        return None
+
+    return _auto_cast_columns(df)
+
+
+def _auto_cast_columns(df: pd.DataFrame) -> pd.DataFrame:
+    df_casted = df.copy()
+    datetime_keywords = [
+        "date",
+        "time",
+        "timestamp",
+        "jour",
+        "semaine",
+        "mois",
+        "annee",
+        "year",
+    ]
+    for column in df_casted.columns:
+        if df_casted[column].dtype == object:
+            lower_name = column.lower()
+            if any(keyword in lower_name for keyword in datetime_keywords):
+                converted = pd.to_datetime(df_casted[column], errors="coerce")
+                if converted.notna().sum() > 0:
+                    df_casted[column] = converted
+            else:
+                # Try casting numeric-looking object columns
+                converted = pd.to_numeric(df_casted[column], errors="coerce")
+                if converted.notna().sum() > 0:
+                    df_casted[column] = converted
+    return df_casted
+
+
+def show_overview_page(df: pd.DataFrame) -> None:
+    st.subheader("📄 Aperçu des données")
+    st.dataframe(df, use_container_width=True)
+
+    st.markdown("### Types de colonnes")
+    st.write(df.dtypes)
+
+    if st.checkbox("📈 Afficher les statistiques descriptives"):
+        st.write(df.describe(include="all"))
+
+
+def _render_metric_card(container, metric: KPIMetric) -> None:
+    container.markdown(f"**{metric.label}**")
+    container.markdown(
+        f"<span style='font-size:1.8rem;font-weight:600'>{metric.value}</span>",
+        unsafe_allow_html=True,
+    )
+    if metric.description:
+        container.caption(metric.description)
+    if metric.column:
+        container.caption(f"Colonne source : `{metric.column}`")
+
+
+def show_kpi_page(df: pd.DataFrame) -> None:
+    st.subheader("🎯 Explorateur de KPI")
+    analyzer = KPIAnalyzer(df)
+    metrics, details = analyzer.suggest()
+
+    if not metrics:
+        st.info("Aucun KPI pertinent n'a été détecté automatiquement.")
+        return
+
+    st.markdown("### KPI suggérés")
+    cards_per_row = 3
+    for start in range(0, len(metrics), cards_per_row):
+        row_metrics = metrics[start : start + cards_per_row]
+        columns = st.columns(len(row_metrics))
+        for container, metric in zip(columns, row_metrics):
+            _render_metric_card(container, metric)
+
+    if details:
+        st.markdown("### Analyses complémentaires")
+    for detail in details:
+        st.markdown(f"#### {detail.title}")
+        if detail.description:
+            st.caption(detail.description)
+        st.dataframe(detail.dataframe, use_container_width=True)
+
+
+def show_advanced_page(df: pd.DataFrame) -> None:
+    st.subheader("🔍 Analyse avancée")
+    agent = DataExplorerAgent(df)
+
+    col1, col2 = st.columns(2)
+    with col1:
+        if st.checkbox("Afficher la heatmap de corrélation"):
+            heatmap = agent.correlation_heatmap()
+            st.image(heatmap)
+    with col2:
+        if st.checkbox("Détecter les valeurs aberrantes"):
+            outliers = agent.detect_outliers()
+            if outliers.empty:
+                st.info("Aucune valeur aberrante détectée")
+            else:
+                st.write(outliers)
+
+    if st.checkbox("Clusteriser les données"):
+        n_clusters = st.number_input("Nombre de clusters", min_value=2, max_value=10, value=3)
+        labels = agent.cluster(int(n_clusters))
+        df_clustered = df.copy()
+        df_clustered["cluster"] = labels
+        st.write(df_clustered)
+
+
+if "df" not in st.session_state:
+    st.session_state["df"] = None
+    st.session_state["file_name"] = None
 
 uploaded_file = st.file_uploader(
     "📁 Upload your dataset", type=["csv", "xlsx", "xls", "parquet", "json"]
 )
 
-if uploaded_file:
-    file_name = uploaded_file.name.lower()
-    try:
-        if file_name.endswith(".csv"):
-            df = pd.read_csv(uploaded_file)
-        elif file_name.endswith(".xlsx") or file_name.endswith(".xls"):
-            df = pd.read_excel(uploaded_file)
-        elif file_name.endswith(".parquet"):
-            df = pd.read_parquet(uploaded_file)
-        elif file_name.endswith(".json"):
-            df = pd.read_json(uploaded_file)
-        else:
-            st.error("❌ Format non supporté.")
-            df = None
+dataset = st.session_state.get("df")
+if uploaded_file is not None:
+    dataset = load_dataset(uploaded_file)
+    if dataset is not None:
+        st.session_state["df"] = dataset
+        st.session_state["file_name"] = uploaded_file.name
+        st.success(
+            f"✅ Fichier {uploaded_file.name} chargé avec succès ! Dimensions : "
+            f"{dataset.shape[0]} lignes × {dataset.shape[1]} colonnes"
+        )
+    else:
+        dataset = st.session_state.get("df")
 
-        if df is not None:
-            st.success(
-                f"✅ Fichier chargé avec succès ! Dimensions : {df.shape[0]} lignes × {df.shape[1]} colonnes"
-            )
-            st.dataframe(df, use_container_width=True)
-            st.markdown("### Aperçu rapide des colonnes")
-            st.write(df.dtypes)
-            if st.checkbox("📈 Afficher les statistiques descriptives"):
-                st.write(df.describe(include="all"))
-
-            # AI agent features
-            agent = DataExplorerAgent(df)
-            st.markdown("---")
-            st.header("🔍 Analyse avancée")
-            col1, col2 = st.columns(2)
-            with col1:
-                if st.checkbox("Afficher la heatmap de corrélation"):
-                    heatmap = agent.correlation_heatmap()
-                    st.image(heatmap)
-            with col2:
-                if st.checkbox("Détecter les valeurs aberrantes"):
-                    outliers = agent.detect_outliers()
-                    if outliers.empty:
-                        st.info("Aucune valeur aberrante détectée")
-                    else:
-                        st.write(outliers)
-
-            if st.checkbox("Clusteriser les données"):
-                n_clusters = st.number_input(
-                    "Nombre de clusters", min_value=2, max_value=10, value=3
-                )
-                labels = agent.cluster(n_clusters)
-                df_clustered = df.copy()
-                df_clustered["cluster"] = labels
-                st.write(df_clustered)
-
-    except Exception as e:
-        st.error(f"Erreur lors de la lecture du fichier : {e}")
-else:
+if st.session_state.get("df") is None:
     st.info("Veuillez uploader un fichier CSV, Excel, JSON ou Parquet.")
+    st.stop()
+
+st.sidebar.header("Navigation")
+selected_page = st.sidebar.radio(
+    "Aller à", ("Aperçu des données", "Explorateur de KPI", "Analyse avancée")
+)
+
+file_name = st.session_state.get("file_name")
+if file_name:
+    st.caption(f"Fichier actuellement chargé : **{file_name}**")
+
+dataset = st.session_state["df"]
+
+if selected_page == "Aperçu des données":
+    show_overview_page(dataset)
+elif selected_page == "Explorateur de KPI":
+    show_kpi_page(dataset)
+else:
+    show_advanced_page(dataset)

--- a/kpi_analyzer.py
+++ b/kpi_analyzer.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Tuple
+
+import pandas as pd
+
+
+@dataclass
+class KPIMetric:
+    label: str
+    value: str
+    column: Optional[str]
+    description: str
+
+
+@dataclass
+class KPIDetail:
+    title: str
+    dataframe: pd.DataFrame
+    description: Optional[str] = None
+
+
+def _format_number(value: float, decimals: int = 2) -> str:
+    if pd.isna(value):
+        return "N/A"
+
+    if abs(value) >= 100:
+        formatted = f"{value:,.0f}"
+    else:
+        formatted = f"{value:,.{decimals}f}"
+
+    return formatted.replace(",", "\u202f")
+
+
+def _format_percent(value: float, decimals: int = 1) -> str:
+    if pd.isna(value):
+        return "N/A"
+    return f"{value:.{decimals}%}"
+
+
+class KPIAnalyzer:
+    """Generate KPI suggestions based on dataset column names."""
+
+    def __init__(self, df: pd.DataFrame):
+        self.df = df
+        self.numeric_df = df.select_dtypes(include=["number"])
+        self.categorical_df = df.select_dtypes(include=["object", "category"])
+
+    def suggest(self) -> Tuple[List[KPIMetric], List[KPIDetail]]:
+        metrics: List[KPIMetric] = []
+        details: List[KPIDetail] = []
+
+        metrics.extend(self._base_metrics())
+        metrics.extend(self._numeric_keyword_metrics())
+        metrics.extend(self._categorical_metrics())
+        metrics.extend(self._datetime_metrics())
+
+        details.extend(self._top_categories_details())
+
+        # Deduplicate metrics by (label, column)
+        seen = set()
+        unique_metrics: List[KPIMetric] = []
+        for metric in metrics:
+            key = (metric.label, metric.column)
+            if key in seen:
+                continue
+            seen.add(key)
+            unique_metrics.append(metric)
+
+        return unique_metrics, details
+
+    def _base_metrics(self) -> Iterable[KPIMetric]:
+        rows, cols = self.df.shape
+        return [
+            KPIMetric(
+                label="Lignes disponibles",
+                value=_format_number(rows, decimals=0),
+                column=None,
+                description="Nombre total d'enregistrements dans le fichier.",
+            ),
+            KPIMetric(
+                label="Colonnes disponibles",
+                value=_format_number(cols, decimals=0),
+                column=None,
+                description="Nombre total de colonnes détectées.",
+            ),
+        ]
+
+    def _numeric_keyword_metrics(self) -> Iterable[KPIMetric]:
+        if self.numeric_df.empty:
+            return []
+
+        rules = [
+            {
+                "keywords": ["revenue", "revenu", "sales", "vente", "turnover", "income", "ca"],
+                "label": "Revenu total",
+                "agg": lambda s: s.sum(),
+                "description": "Somme totale des montants de la colonne {column}.",
+            },
+            {
+                "keywords": ["profit", "benef", "margin"],
+                "label": "Profit total",
+                "agg": lambda s: s.sum(),
+                "description": "Bénéfice cumulé calculé sur la colonne {column}.",
+            },
+            {
+                "keywords": ["cost", "cout", "expense", "depense"],
+                "label": "Coût total",
+                "agg": lambda s: s.sum(),
+                "description": "Somme totale des coûts basés sur {column}.",
+            },
+            {
+                "keywords": ["price", "prix", "tarif", "amount", "montant"],
+                "label": "Valeur moyenne",
+                "agg": lambda s: s.mean(),
+                "description": "Valeur moyenne observée dans la colonne {column}.",
+            },
+            {
+                "keywords": ["quantity", "quantite", "qty", "volume"],
+                "label": "Quantité totale",
+                "agg": lambda s: s.sum(),
+                "description": "Volume total agrégé pour la colonne {column}.",
+            },
+            {
+                "keywords": ["rate", "taux", "ratio", "pourcentage"],
+                "label": "Taux moyen",
+                "agg": lambda s: s.mean(),
+                "description": "Taux moyen calculé pour la colonne {column}.",
+                "formatter": _format_percent,
+            },
+            {
+                "keywords": ["score", "note", "evaluation"],
+                "label": "Score moyen",
+                "agg": lambda s: s.mean(),
+                "description": "Score moyen observé dans la colonne {column}.",
+            },
+            {
+                "keywords": ["age"],
+                "label": "Âge moyen",
+                "agg": lambda s: s.mean(),
+                "description": "Âge moyen calculé sur la colonne {column}.",
+            },
+            {
+                "keywords": ["duree", "duration", "temps", "time"],
+                "label": "Durée moyenne",
+                "agg": lambda s: s.mean(),
+                "description": "Durée moyenne mesurée dans la colonne {column}.",
+            },
+        ]
+
+        metrics: List[KPIMetric] = []
+        for col in self.numeric_df.columns:
+            series = self.numeric_df[col].dropna()
+            if series.empty:
+                continue
+            col_lower = col.lower()
+            for rule in rules:
+                if any(keyword in col_lower for keyword in rule["keywords"]):
+                    formatter = rule.get("formatter", _format_number)
+                    value = rule["agg"](series)
+                    formatted_value = formatter(value)
+                    metrics.append(
+                        KPIMetric(
+                            label=f"{rule['label']} ({col})",
+                            value=formatted_value,
+                            column=col,
+                            description=rule["description"].format(column=col),
+                        )
+                    )
+                    break
+            else:
+                # No keyword match: propose generic statistics for prominent columns
+                formatter = _format_number
+                metrics.extend(
+                    [
+                        KPIMetric(
+                            label=f"Moyenne ({col})",
+                            value=formatter(series.mean()),
+                            column=col,
+                            description=f"Valeur moyenne observée pour {col}.",
+                        ),
+                        KPIMetric(
+                            label=f"Somme ({col})",
+                            value=formatter(series.sum()),
+                            column=col,
+                            description=f"Somme totale des valeurs de {col}.",
+                        ),
+                    ]
+                )
+        return metrics
+
+    def _categorical_metrics(self) -> Iterable[KPIMetric]:
+        if self.categorical_df.empty:
+            return []
+
+        metrics: List[KPIMetric] = []
+        rules = [
+            {
+                "keywords": ["client", "customer", "user", "utilisateur", "compte"],
+                "label": "Clients uniques",
+                "description": "Nombre de clients/identifiants uniques présents dans {column}.",
+            },
+            {
+                "keywords": ["produit", "product", "item", "article"],
+                "label": "Produits uniques",
+                "description": "Nombre de produits distincts présents dans {column}.",
+            },
+            {
+                "keywords": ["ville", "city", "pays", "country", "region"],
+                "label": "Localisations uniques",
+                "description": "Nombre d'emplacements distincts détectés dans {column}.",
+            },
+        ]
+
+        for col in self.categorical_df.columns:
+            series = self.categorical_df[col].dropna()
+            if series.empty:
+                continue
+            col_lower = col.lower()
+            for rule in rules:
+                if any(keyword in col_lower for keyword in rule["keywords"]):
+                    metrics.append(
+                        KPIMetric(
+                            label=f"{rule['label']} ({col})",
+                            value=_format_number(series.nunique(), decimals=0),
+                            column=col,
+                            description=rule["description"].format(column=col),
+                        )
+                    )
+                    break
+        return metrics
+
+    def _datetime_metrics(self) -> Iterable[KPIMetric]:
+        datetime_cols = self.df.select_dtypes(include=["datetime64[ns]", "datetimetz"]).columns
+        if not len(datetime_cols):
+            return []
+
+        metrics: List[KPIMetric] = []
+        for col in datetime_cols:
+            series = pd.to_datetime(self.df[col], errors="coerce").dropna()
+            if series.empty:
+                continue
+            metrics.append(
+                KPIMetric(
+                    label=f"Date la plus récente ({col})",
+                    value=series.max().strftime("%Y-%m-%d"),
+                    column=col,
+                    description=f"Dernière date disponible dans {col}.",
+                )
+            )
+            metrics.append(
+                KPIMetric(
+                    label=f"Date la plus ancienne ({col})",
+                    value=series.min().strftime("%Y-%m-%d"),
+                    column=col,
+                    description=f"Première date disponible dans {col}.",
+                )
+            )
+        return metrics
+
+    def _top_categories_details(self) -> Iterable[KPIDetail]:
+        details: List[KPIDetail] = []
+        if self.categorical_df.empty:
+            return details
+
+        for col in self.categorical_df.columns:
+            series = self.categorical_df[col].dropna()
+            unique_count = series.nunique()
+            if unique_count == 0 or unique_count > 25:
+                continue
+            counts = series.value_counts().reset_index()
+            counts.columns = [col, "Occurrences"]
+            counts["Occurrences"] = counts["Occurrences"].astype(int)
+            details.append(
+                KPIDetail(
+                    title=f"Répartition de {col}",
+                    dataframe=counts,
+                    description="Top catégories pour aider à identifier les segments dominants.",
+                )
+            )
+        return details


### PR DESCRIPTION
## Summary
- restructure the Streamlit app with multi-page navigation and improved dataset loading helpers
- add automatic KPI suggestions and supporting analytics cards driven by column name heuristics
- keep advanced visualisations on their own page while auto-casting likely numeric and datetime columns

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68df8a9a43d08321b1dc6c2e757cab34